### PR TITLE
[#111022166] enable fitbit subscriber verification

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,2 @@
 [run]
-omit = fitapp/tests*,run_tests.py,*/site-packages/*,*/python?.?/*,*/pypy/*,.tox/*,/opt/python/*
+omit = fitapp/tests*,fitapp/migrations/*,fitapp/south_migrations/*,run_tests.py,*/site-packages/*,*/python?.?/*,*/pypy/*,.tox/*,/opt/python/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ env:
   - TOX_ENV=py34-1.7.X
   - TOX_ENV=py33-1.8.X
   - TOX_ENV=py33-1.7.X
-  - TOX_ENV=py32-1.8.X
-  - TOX_ENV=py32-1.7.X
   - TOX_ENV=py27-1.9.X
   - TOX_ENV=py27-1.8.X
   - TOX_ENV=py27-1.7.X

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -24,6 +24,20 @@ FITAPP_CONSUMER_SECRET
 The secret that goes with the FITAPP_CONSUMER_KEY. You must specify a non-null
 value for this setting.
 
+FITAPP_VERIFICATION_CODE
+------------------------
+
+The verification code fitbit assigns to your app for the purpose of `verifying
+subscriber endpoints
+<https://dev.fitbit.com/docs/subscriptions/#verify-a-subscriber>`_. This is
+optional, and is only needed if you plan on subscriber to user data updates. To
+use this feature, add a subscriber using the
+``Fitbit developer interface<https://dev.fitbit.com/apps>``. Fitbit will
+provide you with a verification code to use here. Once you have deployed the
+code, you can click "Verify" on Fitbit to verify it. We recommend you keep this
+verification code in place as long as you are using the subscriber so that if
+any changes are made, reverification happens automatically.
+
 .. _FITAPP_LOGIN_REDIRECT:
 
 FITAPP_LOGIN_REDIRECT

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -30,7 +30,7 @@ FITAPP_VERIFICATION_CODE
 The verification code fitbit assigns to your app for the purpose of `verifying
 subscriber endpoints
 <https://dev.fitbit.com/docs/subscriptions/#verify-a-subscriber>`_. This is
-optional, and is only needed if you plan on subscriber to user data updates. To
+optional, and is only needed if you plan on subscribing to user data updates. To
 use this feature, add a subscriber using the
 ``Fitbit developer interface<https://dev.fitbit.com/apps>``. Fitbit will
 provide you with a verification code to use here. Once you have deployed the

--- a/fitapp/defaults.py
+++ b/fitapp/defaults.py
@@ -3,6 +3,9 @@
 FITAPP_CONSUMER_KEY = None
 FITAPP_CONSUMER_SECRET = None
 
+# The verification code for verifying subscriber endpoints
+FITAPP_VERIFICATION_CODE = None
+
 # Where to redirect to after Fitbit authentication is successfully completed.
 FITAPP_LOGIN_REDIRECT = '/'
 

--- a/fitapp/tests/test_verification.py
+++ b/fitapp/tests/test_verification.py
@@ -1,0 +1,58 @@
+"""
+Tests in this file are for testing verification of fitbit subscriber endpoints.
+https://dev.fitbit.com/docs/subscriptions/#verify-a-subscriber
+"""
+
+from django.conf import settings
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+from django.test.utils import override_settings
+
+
+class TestVerification(TestCase):
+    """
+    Class to test verification of Fitbit subscriber endpoints
+    """
+
+    def test_404(self):
+        """
+        Check various conditions that should result in a 404
+        """
+        # Empty non-GET requests
+        resp = self.client.post(reverse('fitbit-update'))
+        self.assertEqual(resp.status_code, 404)
+        resp = self.client.put(reverse('fitbit-update'))
+        self.assertEqual(resp.status_code, 404)
+
+        # No code in settings or query string
+        resp = self.client.get(reverse('fitbit-update'))
+        self.assertEqual(resp.status_code, 404)
+
+        # Code in query string, but not in settings
+        resp = self.client.get(reverse('fitbit-update') + '?verify=code')
+        self.assertEqual(resp.status_code, 404)
+
+        with override_settings(FITAPP_VERIFICATION_CODE='VERIFICATION_CODE'):
+            # Code in settings, but not query string
+            resp = self.client.get(reverse('fitbit-update'))
+            self.assertEqual(resp.status_code, 404)
+
+            # Code in settings, wrong code in query string
+            resp = self.client.get(reverse('fitbit-update') + '?verify=code')
+            self.assertEqual(resp.status_code, 404)
+
+    @override_settings(FITAPP_VERIFICATION_CODE='VERIFICATION_CODE')
+    def test_verify(self):
+        """
+        Test the verification process. It consists of two GET requests:
+        1. Contains a verify query param containing the verification code we
+           have specified in the ``FITAPP_VERIFICATION_CODE`` setting. We
+           should respond with a HTTP 204 code.
+        2. Contains a verify query param containing a purposefully invalid
+           verification code. We should respond with a 404
+        """
+
+        for verify, status in [('VERIFICATION_CODE', 204), ('BAD_CODE', 404)]:
+            query_string = '?verify=' + verify
+            resp = self.client.get(reverse('fitbit-update') + query_string)
+            self.assertEqual(resp.status_code, status)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,2 +1,4 @@
 fitbit>=0.1.2
 celery>=3.1.13
+simplejson
+six

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,5 +3,5 @@
 
 django-debug-toolbar
 sphinx
-django>=1.4.0,<1.9.0
-tox>=1.8.0,<1.9.0
+django>=1.4,<1.10
+tox>=1.8,<2.4

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,3 @@
-coverage>=3.7.0,<4.0
-mock>=1.0.0,<1.1.0
+coverage>=3.7,<4.1
+mock>=1,<1.4
 freezegun>=0.2.3,<0.4

--- a/run_tests.py
+++ b/run_tests.py
@@ -89,6 +89,7 @@ def run_tests():
     if covlevel:
         cov.stop()
         cov.save()
+        cov.html_report()
 
     sys.exit(exit_val)
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
         "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.2",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ envlist = pypy-1.9.X,pypy-1.8.X,pypy-1.7.X,pypy-1.4.X,
           py35-trunk,py35-1.9.X,
           py34-trunk,py34-1.9.X,py34-1.8.X,py34-1.7.X,
           py33-1.8.X,py33-1.7.X,
-          py32-1.8.X,py32-1.7.X,
           py27-1.9.X,py27-1.8.X,py27-1.7.X,py27-1.4.X,
           py26-1.4.X
 
@@ -89,14 +88,6 @@ deps = {[django18]deps}
 
 [testenv:py33-1.7.X]
 basepython = python3.3
-deps = {[django17]deps}
-
-[testenv:py32-1.8.X]
-basepython = python3.2
-deps = {[django18]deps}
-
-[testenv:py32-1.7.X]
-basepython = python3.2
 deps = {[django17]deps}
 
 [testenv:py27-trunk]


### PR DESCRIPTION
@orcasgit/orcas-developers Please review. This adds support for [verifying subscriber endpoints](https://dev.fitbit.com/docs/subscriptions/#verify-a-subscriber). I made some maintenance updates too:

- Use six to simplify string type checking in Python 2/3
- Use simplejson to simplify json error handling across Python 2/3
- Create HTML coverage report when running tests
- Ignore migration directories in coverage reports
- Handle specific exceptions in `update` view
- Update upper end of requirements to the latest tested versions
- Drop support for Python 3.2, which is no longer supported in the latest version of `coverage`
