### PR TITLE
Refresh callback

### DIFF
--- a/fitapp/models.py
+++ b/fitapp/models.py
@@ -20,11 +20,20 @@ class UserFitbit(models.Model):
     def __str__(self):
         return self.user.__str__()
 
+    def refresh_cb(self, token):
+        # Update the token if necessary. We are making sure we have a valid
+        # access_token and refresh_token next time we request Fitbit data
+        if token['access_token'] != self.access_token:
+            self.access_token = token['access_token']
+            self.refresh_token = token['refresh_token']
+            self.save()
+
     def get_user_data(self):
         return {
             'user_id': self.fitbit_user,
             'access_token': self.access_token,
-            'refresh_token': self.refresh_token
+            'refresh_token': self.refresh_token,
+            'refresh_cb': self.refresh_cb,
         }
 
 

--- a/fitapp/models.py
+++ b/fitapp/models.py
@@ -21,12 +21,10 @@ class UserFitbit(models.Model):
         return self.user.__str__()
 
     def refresh_cb(self, token):
-        # Update the token if necessary. We are making sure we have a valid
-        # access_token and refresh_token next time we request Fitbit data
-        if token['access_token'] != self.access_token:
-            self.access_token = token['access_token']
-            self.refresh_token = token['refresh_token']
-            self.save()
+        """ Called when the OAuth token has been refreshed """
+        self.access_token = token['access_token']
+        self.refresh_token = token['refresh_token']
+        self.save()
 
     def get_user_data(self):
         return {

--- a/fitapp/tests/test_integration.py
+++ b/fitapp/tests/test_integration.py
@@ -290,8 +290,9 @@ class TestLogoutView(FitappTestBase):
     def test_get(self, apply_async):
         """Logout view should remove associated UserFitbit and redirect."""
         response = self._get()
-        apply_async.assert_called_once_with(kwargs=self.fbuser.get_user_data(),
-                                            countdown=5)
+        kwargs = self.fbuser.get_user_data()
+        del kwargs['refresh_cb']
+        apply_async.assert_called_once_with(kwargs=kwargs, countdown=5)
         self.assertRedirectsNoFollow(
             response, utils.get_setting('FITAPP_LOGIN_REDIRECT'))
         self.assertEqual(UserFitbit.objects.count(), 0)
@@ -315,8 +316,9 @@ class TestLogoutView(FitappTestBase):
     def test_next(self, apply_async):
         """Logout view should redirect to GET['next'] if available."""
         response = self._get(get_kwargs={'next': '/test'})
-        apply_async.assert_called_with(kwargs=self.fbuser.get_user_data(),
-                                       countdown=5)
+        kwargs = self.fbuser.get_user_data()
+        del kwargs['refresh_cb']
+        apply_async.assert_called_with(kwargs=kwargs, countdown=5)
         self.assertRedirectsNoFollow(response, '/test')
         self.assertEqual(UserFitbit.objects.count(), 0)
 

--- a/fitapp/tests/test_models.py
+++ b/fitapp/tests/test_models.py
@@ -12,6 +12,7 @@ class TestFitappModels(FitappTestBase):
         self.assertEqual(self.fbuser.get_user_data(), {
             'access_token': self.fbuser.access_token,
             'refresh_token': self.fbuser.refresh_token,
+            'refresh_cb': self.fbuser.refresh_cb,
             'user_id': self.fbuser.fitbit_user
         })
 

--- a/fitapp/tests/test_retrieval.py
+++ b/fitapp/tests/test_retrieval.py
@@ -111,8 +111,9 @@ class TestRetrievalUtility(FitappTestBase):
         with patch.object(FitbitOauth2Client, '_request') as r:
             r.side_effect = [
                 fitbit_exceptions.HTTPUnauthorized(
-                    MagicMock(code=401, content=b'unauth response')),
-                MagicMock(code=200, content='{"activities-steps": [1, 2, 3]}')
+                    MagicMock(status_code=401, content=b'unauth response')),
+                MagicMock(status_code=200,
+                          content=b'{"activities-steps": [1, 2, 3]}')
             ]
             with patch.object(OAuth2Session, 'refresh_token') as rt:
                 rt.return_value = {

--- a/fitapp/utils.py
+++ b/fitapp/utils.py
@@ -67,13 +67,6 @@ def get_fitbit_data(fbuser, resource_type, base_date=None, period=None,
     data = fb.time_series(resource_path, user_id=fbuser.fitbit_user,
                           period=period, base_date=base_date,
                           end_date=end_date)
-
-    # Update the token if necessary. We are making sure we have a valid
-    # access_token and refresh_token next time we request Fitbit data
-    if fb.client.token['access_token'] != fbuser.access_token:
-        fbuser.access_token = fb.client.token['access_token']
-        fbuser.refresh_token = fb.client.token['refresh_token']
-        fbuser.save()
     return data[resource_path.replace('/', '-')]
 
 

--- a/fitapp/views.py
+++ b/fitapp/views.py
@@ -179,7 +179,10 @@ def logout(request):
                 SUBSCRIBER_ID = utils.get_setting('FITAPP_SUBSCRIBER_ID')
             except ImproperlyConfigured:
                 return redirect(reverse('fitbit-error'))
-            unsubscribe.apply_async(kwargs=fbuser.get_user_data(), countdown=5)
+            kwargs = fbuser.get_user_data()
+            # The refresh callback is not desired since the user will be gone
+            del kwargs['refresh_cb']
+            unsubscribe.apply_async(kwargs=kwargs, countdown=5)
         fbuser.delete()
     next_url = request.GET.get('next', None) or utils.get_setting(
         'FITAPP_LOGOUT_REDIRECT')

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-fitbit==0.2.2
+fitbit>=0.2.4
 celery>=3.1.13
 simplejson
 six


### PR DESCRIPTION
@orcasgit/orcas-developers Please review. This should make it so the tokens always refresh automatically as long as the code uses `get_user_data()` to generate the kwargs for creating the fitbit API.

See https://github.com/orcasgit/django-fitbit/pull/35 and https://github.com/orcasgit/django-fitbit/issues/37